### PR TITLE
Add DAP analytics tracking code, closes #30

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -30,4 +30,6 @@
       window.location = window.location.href.replace('www.', '');
     }
   </script>
+  <!-- We participate in the US government's analytics program. See the data at analytics.usa.gov. -->
+  <script async type="text/javascript" src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=GSA" id="_fed_an_ua_tag"></script>
 </head>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -31,5 +31,5 @@
     }
   </script>
   <!-- We participate in the US government's analytics program. See the data at analytics.usa.gov. -->
-  <script async type="text/javascript" src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=GSA" id="_fed_an_ua_tag"></script>
+  <script async type="text/javascript" src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=GSA&subagency=CTO&sitetopic=IT&sp=term&dclink=true&enhlink=true&cto=12" id="_fed_an_ua_tag"></script>
 </head>


### PR DESCRIPTION
Add DAP analytics script just before the closing head tag in _includes/head.html with the following parameters:

agency=GSA  //set agency
subagency=CTO  //set sub-agency
sitetopic=IT  //set site topic
sp=term   //site search tracking
dclink=true  //enable demographic data
enhlink=true  //sets Enhanced Link Attribution, so that Google Analytics understands that in-page links are separate
cto=12  //set cookie expiration to 12 months

An explanation of each of these can be found in the DAP UA Code v3.1, [DAP Code Capabilities Summary & Reference document](https://www.digitalgov.gov/files/2014/05/DAP_v3.1_CodeSummary_Aug2016-1-1.pdf)