### PR TITLE
Add resources section to home - closes #51, #52

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -52,6 +52,22 @@
             </div>
         </div>
     </section>
+    <section class="usa-section-light">
+      <div class="usa-grid">
+        <div class="usa-width-one-half">
+          <h3>Open Gov Plan 2016-2018</h3>
+          <p>This is the fourth update of GSA’s Open Government Plan. It continues our efforts to raise the bar on good management and demands higher standards of accountability by asking the public to become active participants in our government.</p>
+          <div class="usa-button-block"><a href="https://gsa.github.io/opengovplan/" class="usa-button  usa-button-outline">Learn More</a>
+          </div>
+        </div>
+        <div class="usa-width-one-half">
+          <h3>GSA Labs</h3>
+          <p>Welcome to GSA Labs! This is a community where government agencies can share applications, code, and best practices. It is designed to maximize the collective thought leadership across the entire Government.</p>
+          <div class="usa-button-block"><a href="https://labs.gsa.gov" class="usa-button  usa-button-outline">Learn More</a>
+          </div>
+        </div>
+      </div>
+    </section>
     {% include contact.html %}
 
     <div id="footer">{% include footer.html %}</div>


### PR DESCRIPTION
To highlight the GSA Open gov plan and GSA labs.
Closes issues #51 and #52.

Preview:
<img width="1497" alt="screen shot 2017-01-26 at 8 14 25 am" src="https://cloud.githubusercontent.com/assets/2197515/22332567/82ce4742-e39f-11e6-9547-8cbb02efdbd3.png">

