### PR TITLE
Update url

### DIFF
--- a/_layouts/code.html
+++ b/_layouts/code.html
@@ -30,7 +30,7 @@
                 <i class="icon flag fa-users"></i>
                 <h3>M-16-21</h3>
                 <p>The White House policy telling federal agencies to account for code developed by the agency and publish at least 20% to the public.</p>
-                <div class="usa-button-block"><a href="https://www.whitehouse.gov/sites/default/files/omb/memoranda/2016/m_16_21.pdf" class="usa-button  usa-button-outline">View</a>
+                <div class="usa-button-block"><a href="https://sourcecode.cio.gov/" class="usa-button  usa-button-outline">View</a>
                 </div>
             </div>
 


### PR DESCRIPTION
Changes proposed with this PR:

- Points the url for the M-16-21 policy on Code page to https://sourcecode.cio.gov/
- Closes #76 
