### PR TITLE
Add developer redirects

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,4 +6,5 @@ gem 'html-proofer'
 
 group :jekyll_plugins do
   gem 'jekyll_pages_api'
+  gem 'jekyll-redirect-from'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,6 +42,8 @@ GEM
       safe_yaml (~> 1.0)
     jekyll-autoprefixer (1.0.1)
       autoprefixer-rails (~> 6.3.6)
+    jekyll-redirect-from (0.12.1)
+      jekyll (~> 3.3)
     jekyll-sass-converter (1.5.0)
       sass (~> 3.4)
     jekyll-watch (1.5.0)
@@ -83,6 +85,7 @@ DEPENDENCIES
   html-proofer
   jekyll
   jekyll-autoprefixer
+  jekyll-redirect-from
   jekyll_pages_api
 
 BUNDLED WITH

--- a/pages/home.md
+++ b/pages/home.md
@@ -1,6 +1,9 @@
 ---
 layout: home
 permalink: /
+redirect_from:
+  - /developers/
+  - /developer/
 hero-image: /assets/img/feature-background.jpg
 hero-text: "Unlock the power of government data"
 hero-button-text: Hey, me too!


### PR DESCRIPTION
Changes proposed:

- Add the [jekyll-redirect-from](https://github.com/jekyll/jekyll-redirect-from) plugin
- Add redirects for /developer and /developers to the home page

<img width="422" alt="screen shot 2017-03-16 at 12 25 59 pm" src="https://cloud.githubusercontent.com/assets/2197515/24007003/be9917d2-0a43-11e7-9c84-645d7411ad9a.png">
