### PR TITLE
Link to GSA guidance on publishing data sets

### DIFF
--- a/pages/data.html
+++ b/pages/data.html
@@ -30,7 +30,7 @@ banner-button-link: https://catalog.data.gov/organization/gsa-gov
                 <i class="icon flag alt fa-laptop"></i>
                 <h3>Open Data Publication Process</h3>
                 <p>This document is provided as an aid to learn what to do to get your GSA data released in the open.</p>
-                <div class="usa-button-block"><a href="{{ Open_Data_Publication_Process.docx | prepend: site.baseurl }}" class="usa-button  usa-button-outline">View</a>
+                <div class="usa-button-block"><a href=" https://www.gsa.gov/portal/directive/d0/content/699006" class="usa-button  usa-button-outline">View</a>
                 </div>
             </div>
 


### PR DESCRIPTION
Link out to the [GSA policy for publishing datasets](https://www.gsa.gov/portal/directive/d0/content/699006) off of the /data page.
