### PR TITLE
Deprecate two APIs

### DIFF
--- a/_data/api-list.yml
+++ b/_data/api-list.yml
@@ -34,9 +34,6 @@
 - title: Federal Procurement Data System - FPDS API
   description: SOAP and XML web services are used in FPDS-NG to provide interoperability with various federal procurement systems.
   url: https://www.fpds.gov/downloads/FPDS-Specifications-WebServices_Integration_Specifications_V1.4.doc
-- title: FOIA API
-  description: The FOIA Modernization API lists all agencies for whom a FOIA request can be submitted. It also includes components within those agencies that are large enough (and well known enough) to have their own FOIA system.
-  url: http://foia-hub.readthedocs.io/en/latest/api.html
 - title: Go.USA.gov API
   description: Go.USA.gov is a URL shortener for government employees. The API can shorten, preview, and show clicks on short URLs.
   url: https://go.usa.gov/api

--- a/_data/api-list.yml
+++ b/_data/api-list.yml
@@ -4,9 +4,6 @@
 - title: Auctions API
   description: The Auctions API is a GET API which has currently one operation. The operation will retrieve GSA Auctions data. GSA Auctions offers Federal personal property assets ranging from common place items (such as office equipment and furniture) to more select products like scientific equipment, heavy machinery, airplanes, vessels and vehicles.
   url: http://gsa.github.io/auctions_api/
-- title: Corporate Consumer Contact Information
-  description: Based on the information collected for the Consumer Action Handbook.
-  url: http://www.usa.gov/About/developer-resources/corporation-contact-directory/index.shtml
 - title: Data.gov CKAN API
   description: The government-wide data catalog available at Data.gov.
   url: http://www.data.gov/developers/apis


### PR DESCRIPTION
Removes two deprecated APIs from the API directory:

- FOIA API
- Corporate Consumer Contact Information