### PR TITLE
Updating style of api docs nav bar to fix wrapping issue

### DIFF
--- a/_layouts/apidocs.html
+++ b/_layouts/apidocs.html
@@ -2,7 +2,7 @@
 layout: page
 ---
 
-<aside class="usa-width-one-fourth sidebar-sticky" >
+<aside class="usa-width-one-fourth sidebar-sticky" style="word-wrap: break-word;">
   {{ content | toc_only }}
 </aside>
 


### PR DESCRIPTION
Added break-word wrapping to nav bar for long method names.

Fixes #294 