### PR TITLE
remove email on API pages

### DIFF
--- a/_includes/footerapi.html
+++ b/_includes/footerapi.html
@@ -1,0 +1,33 @@
+  <footer class="usa-footer usa-background-dark">
+    <div class="usa-grid">
+      <nav>
+        <div class="usa-width-one-fourth">
+          <h3>Work</h3>
+          <ul class="usa-unstyled-list">
+            <li><a href="{{ '/about' | prepend: site.baseurl }}">About us</a></li>
+            <li><a href="https://github.com/orgs/GSA/teams/cto/repositories">Our projects</a></li>
+          </ul>
+        </div>
+        <div class="usa-width-one-fourth">
+          <h3>Open Source</h3>
+          <ul class="usa-unstyled-list">
+            <li><a href="https://github.com/gsa/open-gsa-redesign">Edit this site</a></li>
+<!--            <li><a href="https://github.com/gsa/open-gsa-redesign/issues">Submit feedback</a></li> -->
+          </ul>
+        </div>
+        <div class="usa-width-one-fourth">
+          <!-- <h3>Contact Us</h3>
+          <ul class="usa-unstyled-list">
+            <li><a href="mailto:cto@gsa.gov">Email us</a></li> -->
+        </div>
+        <div class="usa-footer-logo usa-width-one-fourth">
+          {% if site.footer.text %}
+            <p><small>{{ site.footer.text }}</small></p>
+          {% endif %}
+          {% if site.footer.image %}
+            <p><img src="{{ site.footer.image | prepend: site.baseurl }}" alt="{{ site.footer.image-alt }}" class="logo"></p>
+          {% endif %}
+        </div>
+      </nav>
+    </div>
+  </footer>

--- a/_layouts/apidocs.html
+++ b/_layouts/apidocs.html
@@ -1,5 +1,5 @@
 ---
-layout: page
+layout: pageapi
 ---
 
 <aside class="usa-width-one-fourth sidebar-sticky" style="word-wrap: break-word;">

--- a/_layouts/baseapi.html
+++ b/_layouts/baseapi.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+
+{% include head.html %}
+
+<body>
+    <div id="wrapper">
+        <div id="header">{% include header.html %}</div>
+        <div id="content">{{ content }}</div>
+        <div id="footer">{% include footerapi.html %}</div>
+
+    </div>
+      {% include javascript.html %}
+</body>
+
+</html>

--- a/_layouts/pageapi.html
+++ b/_layouts/pageapi.html
@@ -1,0 +1,13 @@
+---
+layout: baseapi
+---
+{% if page.banner-heading %}
+  {% include banner-header.html %}
+{% endif %}
+
+<main class="usa-grid" id="main" tabindex="-1">
+  <section>
+    {{ content }}
+  </section>
+  <div class="fixed-page-height"></div>
+</main>


### PR DESCRIPTION
This removes the CTO contact information on the bottom of API docs pages.

This is to remove confusion by users about how to get in touch for support on a specific API.