### PR TITLE
Remove calls to action at top of page

### DIFF
--- a/pages/api.html
+++ b/pages/api.html
@@ -3,6 +3,8 @@ layout: base
 title: APIs
 permalink: /api/
 category: api
+banner-heading: GSA API Directory
+banner-text: These following GSA APIs cover a range of important data and functionality. Some of the APIs are available to the general public, and others are for GSA partners only.
 ---
 
 
@@ -13,7 +15,6 @@ category: api
 
     <section class="usa-section usa-section-dark">
         <div class="usa-grid-full" id="api-directory">
-            <h2 style="text-align: center;">GSA API Directory</h2> 
             <div class="usa-width-one-whole data-list">
                 {% for apis in site.data.api-list %}
                     <article class="data-listing">

--- a/pages/api.html
+++ b/pages/api.html
@@ -3,11 +3,6 @@ layout: base
 title: APIs
 permalink: /api/
 category: api
-banner-heading: GSA APIs
-banner-text: GSA publishes Application Programming Interfaces (APIs) for many of our open datasets. This provides information to the public in a standardized and machine-readable format for public use. These APIs cover a range of important data and functionality. Software developers and researchers can use these resources to help people find useful government information.
-banner-button-text: Explore API Directory
-banner-button-link: index.html#api-directory
-banner-button-title: Explore API Directory
 ---
 
 
@@ -15,36 +10,6 @@ banner-button-title: Explore API Directory
 {% if page.banner-heading %}
   {% include banner-header.html %}
 {% endif %}
-
-    <section class="banner functions">
-        <div class="usa-grid-full" align="center">
-          <h2>APIs and Developer Tools</h2>
-        <br>
-            <div class="usa-width-one-third">
-                <i class="icon flag fa-cubes"></i>
-                <h3>GSA API Standards</h3>
-                <p>GSA's recommended best practices, conventions, and standards for APIs. We encourage GSA development groups to check out these standards when developing APIs.</p>
-                <div class="usa-button-block"><a href="https://github.com/GSA/api-standards" class="usa-button  usa-button-outline">View</a>
-                </div>
-            </div>
-
-            <div class="usa-width-one-third">
-                <i class="icon flag alt2 fa-cogs"></i>
-                <h3>Api.Data.Gov</h3>
-                <p>Free API management service for federal agencies, making it easier for you to release and manage your APIs.</p>
-                <div class="usa-button-block"><a href="http://api.data.gov/about/" class="usa-button  usa-button-outline">View</a>
-                </div>
-            </div>
-
-            <div class="usa-width-one-third">
-                <i class="icon flag alt fa-life-ring"></i>
-                <h3>Support for GSA APIs</h3>
-                <p>If you have a question or issue related to a GSA API, you can post your issue here.</p>
-                <div class="usa-button-block"><a href="https://github.com/GSA/GSA-APIs/issues" class="usa-button  usa-button-outline">View</a>
-                </div>
-            </div>
-        </div>
-    </section>
 
     <section class="usa-section usa-section-dark">
         <div class="usa-grid-full" id="api-directory">


### PR DESCRIPTION
Simplify structure based on feedback from Summer Fellowship.