### PR TITLE
Replace private URL in footer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -5,7 +5,7 @@
           <h3>Work</h3>
           <ul class="usa-unstyled-list">
             <li><a href="{{ '/about' | prepend: site.baseurl }}">About us</a></li>
-            <li><a href="https://github.com/orgs/GSA/teams/cto/repositories">Our projects</a></li>
+            <li><a href="https://github.com/GSA/">Our projects</a></li>
           </ul>
         </div>
         <div class="usa-width-one-fourth">

--- a/_includes/footerapi.html
+++ b/_includes/footerapi.html
@@ -5,7 +5,7 @@
           <h3>Work</h3>
           <ul class="usa-unstyled-list">
             <li><a href="{{ '/about' | prepend: site.baseurl }}">About us</a></li>
-            <li><a href="https://github.com/orgs/GSA/teams/cto/repositories">Our projects</a></li>
+            <li><a href="https://github.com/GSA/">Our projects</a></li>
           </ul>
         </div>
         <div class="usa-width-one-fourth">


### PR DESCRIPTION
Fix #547
https://github.com/orgs/GSA/teams/cto/repositories is inaccessible to the public.