### PR TITLE
New CALC Pricing API homepage

### DIFF
--- a/_data/api-list.yml
+++ b/_data/api-list.yml
@@ -15,7 +15,7 @@
   url: https://gsa.github.io/auctions_api/
 - title: Contract-Awarded Labor Category (CALC) API
   description: CALC's API is used by CALC's front-end Data Explorer application to display labor rate data for awarded prices on GSA services schedules, and can also be accessed by any third-party application over the public internet. CALC (Contract Awarded Labor Category) tool searches awarded hourly rate prices on the eight GSA professional services schedules and returns comparable labor categories and prices based on search criteria and filters used.
-  url: https://calc.gsa.gov/api/
+  url: https://buy.gsa.gov/pricing/mas/api
 - title: Data.gov CKAN API
   description: The government-wide data catalog available at Data.gov.
   url: https://open.gsa.gov/api/datadotgov/


### PR DESCRIPTION
calc.gsa.gov is now buy.gsa.gov/pricing