### PR TITLE
Add Thumbnail URL to Docs

### DIFF
--- a/_apidocs/searchgov-results.md
+++ b/_apidocs/searchgov-results.md
@@ -120,6 +120,7 @@ Sites indexed via sitemaps or crawling will use the `/i14y` endpoint. Because mo
       | url              | URL of the document
       | snippet          | Summary of the document
       | publication_date | Publication date of the document (not available on commercial results)
+      | thumbnail_url    | The [Open Graph](https://ogp.me/) image associated with the document
 
       **If `include_facets=true` in your request**, the following fields may show as well. We only display fields with content, so some result sets may not have all fields indicated here.
 

--- a/_apidocs/searchgov-results/v2/openapi.yml
+++ b/_apidocs/searchgov-results/v2/openapi.yml
@@ -196,6 +196,9 @@ components:
               type: string
               format: date
               description: Publication date of the document (not available on commercial results)
+            thumbnail_url:
+              type: string
+              description: URL of the Open Graph Image of the document
             audience:
               type: string
               description: Audience of the document. Only included if a value for the field exists. 


### PR DESCRIPTION
This PR adds the `thumbnail_url` field to the Search.gov Results API documentation.