### PR TITLE
Twitter Removal and Date Filtering Addition

### DIFF
--- a/_apidocs/searchgov-results.md
+++ b/_apidocs/searchgov-results.md
@@ -74,11 +74,15 @@ Sites indexed via sitemaps or crawling will use the `/i14y` endpoint. Because mo
   | include_facets      			| The default is `false`. To enable facet features, set this to `true` 
   | audience                        | Returns results that match any of the specified terms in the Audience field. Ex. `audience=students, policymakers` would return results with an audience of students **or** policymakers. Accepts a comma-separated list of strings. 
   | content_type                    | Returns results that match any of the specified terms in the Content Type field. Ex. `content_type=article, blog post` would return results with a content type of article **or** blog post. Accepts a comma-separated list of strings. 
+  | created_since                   | Sets a lower bound for the `created` date. Date must be in ISO Format (YYYY-MM-DD).
+  | created_until                   | Sets an upper bound for the `created` date. Date must be in ISO Format (YYYY-MM-DD).
   | mime_type                       | Returns results that match any of the specified terms in the mime_type field, which indicates the file type of the document. Ex. `mime_type=text/html, application/pdf` would return results with a MIME type of text/html **or** application/pdf. Accepts a comma-separated list of strings. [Read about common MIME types](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types).
   | searchgov_custom1               | Returns results that match any of the specified terms in the searchgov_custom1 field. Accepts a comma-separated list of strings.
   | searchgov_custom2               | Returns results that match any of the specified terms in the searchgov_custom2 field. Accepts a comma-separated list of strings.
   | searchgov_custom3               | Returns results that match any of the specified terms in the searchgov_custom3 field. Accepts a comma-separated list of strings.
   | tags                            | Returns results that match any of the specified terms in the tags field. Accepts a comma-separated list of strings.
+  | updated_since                   | Sets a lower bound for the `changed` date. Date must be in ISO Format (YYYY-MM-DD).
+  | updated_until                   | Sets an upper bound for the `changed` date. Date must be in ISO Format (YYYY-MM-DD).
 
 
 ## Expected Results
@@ -132,6 +136,7 @@ Sites indexed via sitemaps or crawling will use the `/i14y` endpoint. Because mo
       | searchgov_custom1 | Search.gov custom field 1 content associated with the document
       | searchgov_custom2 | Search.gov custom field 2 content associated with the document
       | searchgov_custom3 | Search.gov custom field 3 content associated with the document
+      | updated_date      | The last updated date of the document 
 
   * ### web:aggregations
     
@@ -143,6 +148,15 @@ Sites indexed via sitemaps or crawling will use the `/i14y` endpoint. Because mo
     | :--          | :--
     | agg_key | Name of the facet value
     | doc_count | Number of documents matching the facet value
+
+    If the field represents a date range, additional properties will be present to indicate the start and end dates of the range.
+
+    | Values       | Description
+    | :--          | :--
+    | to           | Returns the upper bound of the date range in Unix epoch time
+    | from         | Returns the lower bound of the date range in Unix epoch time
+    | to_as_string | Returns the upper bound of the date range as a string in M/D/YYYY format
+    | from_as_string | Returns the lower bound of the date range as a string in M/D/YYYY format
 
   * ### text\_best_bets
 

--- a/_apidocs/searchgov-results.md
+++ b/_apidocs/searchgov-results.md
@@ -13,7 +13,6 @@ This API exposes all relevant Search.gov results “modules” in a single JSON 
   * Best bets
   * Health topics
   * Job openings
-  * Recent tweets
   * Recent news
   * Recent video news
   * Federal Register documents
@@ -210,17 +209,6 @@ Sites indexed via sitemaps or crawling will use the `/i14y` endpoint. Because mo
       | maximum            				| Maximum salary of the job opening
       | rate\_interval\_code			| Rate interval code of the job opening
       | org\_codes						| Organization codes
-
-  * ### recent_tweets
-
-      | Values            	| Description
-      | :--               	| :--
-      | text              	| Text of the tweet
-      | url               	| URL of the tweet
-      | name              	| Name of the tweet author
-      | screen\_name       	| Screen name of the tweet author
-      | profile\_image_url 	| URL of the tweet author profile image
-      | created\_at 		| Date of creation      
 
   * ### federal\_register_documents
 

--- a/_apidocs/searchgov-results/v2/openapi.yml
+++ b/_apidocs/searchgov-results/v2/openapi.yml
@@ -143,7 +143,6 @@ paths:
                   - $ref: '#/components/schemas/graphic_best_bets'
                   - $ref: '#/components/schemas/health_topics'
                   - $ref: '#/components/schemas/job_openings'
-                  - $ref: '#/components/schemas/recent_tweets'
                   - $ref: '#/components/schemas/federal_register_documents'
                   - $ref: '#/components/schemas/related_search_terms'
         default:
@@ -483,27 +482,6 @@ components:
         org_codes:
           type: string
           description: Organization codes
-    recent_tweets:
-      type: array
-      properties: 
-        text:
-          type: string
-          description: Text of the tweet
-        url:
-          type: string
-          description: URL of the tweet 
-        name:
-          type: string
-          description: Name of the tweet author
-        screen_name:
-          type: string
-          description: Screen name of the tweet author
-        profile_image_url:
-          type: string
-          description: URL of the tweet author profile image
-        created_at:
-          type: string
-          description: Date of creation
     federal_register_documents:
       type: array
       properties: 

--- a/_apidocs/searchgov-results/v2/openapi.yml
+++ b/_apidocs/searchgov-results/v2/openapi.yml
@@ -90,6 +90,22 @@ paths:
           schema:
             type: string
             format: string
+        - name: created_until
+          in: query
+          description: 'Allows you to set an upper bound for the date the document was created.'
+          required: false
+          schema:
+            type: string
+            format: date
+            description: The day in YYYY-MM-DD format.
+        - name: created_since
+          in: query
+          description: 'Allows you to set an lower bound for the date the document was created.'
+          required: false
+          schema:
+            type: string
+            format: date
+            description: The day in YYYY-MM-DD format.
         - name: mime_type
           in: query
           description: 'Allows you to filter results based on the Mimetype field. Accepts a comma-separated list of strings.'
@@ -125,6 +141,22 @@ paths:
           schema:
             type: string
             format: string
+        - name: updated_since
+          in: query
+          description: 'Allows you to set an upper bound for the date the document was last updated.'
+          required: false
+          schema:
+            type: string
+            format: date
+            description: The day in YYYY-MM-DD format.
+        - name: updated_until
+          in: query
+          description: 'Allows you to set an lower bound for the date the document was last updated.'
+          required: false
+          schema:
+            type: string
+            format: date
+            description: The day in YYYY-MM-DD format.
       tags:
       - search
       responses:
@@ -219,6 +251,10 @@ components:
             searchgov_custom3:
               type: array
               description: Search.gov custom field 3 content associated with the document. Only included if a value for the field exists. 
+            updated_date:
+              type: string
+              format: date
+              description: Last updated date of the document 
         aggregations:
           type: array
           description: An array of facet objects containing the number of documents associated with each facet value. Within each item, an object representing a facet field (ex. content_type) will have the properties listed below.
@@ -229,6 +265,20 @@ components:
             doc_count:
               type: integer
               description: Number of documents matching the facet value
+            to:
+              type: integer
+              description: Upper bound of date range in Unix epoch date format. 
+            from:
+              type: integer
+              description: Lower bound of date range in Unix epoch date format. 
+            to_as_string:
+              type: string
+              format: date
+              description: Upper bound of date range in  m/d/YYYY format.
+            from_as_string:
+              type: string
+              format: date
+              description: Lower bound of date range in  m/d/YYYY format.
 
 
 


### PR DESCRIPTION
## Summary
This PR removes references to the now-deprecated Twitter functionality, as well as adds information on how to filter your result set by providing date ranges. 


## Preview URL
[Search.gov Results API Documentation Page](https://federalist-ecc58765-2903-48b3-920c-5d93318ad084.sites.pages.cloud.gov/preview/gsa/open-gsa-redesign/afarooque-searchgov-resultsapi-updates/api/searchgov-results/)