### PR TITLE
Update oss.html

### DIFF
--- a/pages/oss.html
+++ b/pages/oss.html
@@ -25,7 +25,7 @@ sidenav: docs
 
 <ol>
     <li>
-    <p>We are working with internal offices that develop custom code and explaining the <a href="https://sourcecode.cio.gov/" target="blank">M-16-21</a> and our <a href="{{site.baseurl}}/assets/files/GSAOSSPolicy.pdf" target="_blank">responsibilities</a>.  This includes creating guidance for inventorying and for opening code.
+    <p>We are working with internal offices that develop custom code and explaining the <a href="https://web.archive.org/web/20170121010212/https://sourcecode.cio.gov/" target="blank">M-16-21</a> and our <a href="{{site.baseurl}}/assets/files/GSAOSSPolicy.pdf" target="_blank">responsibilities</a>.  This includes creating guidance for inventorying and for opening code.
     </p>
     </li>
 


### PR DESCRIPTION
https://sourcecode.cio.gov/ is broken, so content should be revised or pointed to an archive.