### PR TITLE
Fixes broken link on code page and corrects references to tech stacks

### DIFF
--- a/_data/code.yml
+++ b/_data/code.yml
@@ -1,21 +1,21 @@
 - title: tech.gsa.gov
-  body: An open source website built using Jekyll and hosted on Federalist where you can learn more about the CTO Office and technology at GSA.
+  body: An open source website built using Hugo and hosted on cloud.gov Pages where you can learn more about the CTO Office and technology at GSA.
   tags:
   - GSA
   - CTO
   category: Code
   url: https://github.com/GSA/cto-website
 - title: open.gsa.gov
-  body: An open source website built using Jekyll and hosted on Federalist offer GSA's open assets - data, APIs, and code.
+  body: An open source website built using Jekyll and hosted on cloud.gov Pages offer GSA's open assets - data, APIs, and code.
   tags:
   - GSA
   - CTO
   category: Code
   url: https://github.com/GSA/open-gsa-redesign
 - title: Data.gov
-  body: 'Data.gov is an open data website that is based on two robust open source projects: CKAN and WordPress.
+  body: 'Data.gov is an open data website that is based on two robust open source projects: CKAN and Eleventy.
     The data catalog at catalog.data.gov is powered by CKAN, while the content seen
-    at Data.gov is powered by WordPress.'
+    at Data.gov is powered by the static-site generator Eleventy.'
   license: https://github.com/GSA/data.gov/blob/master/LICENSE.md
   openSourceProject: 1
   governmentWideReuseProject: 1

--- a/pages/code.html
+++ b/pages/code.html
@@ -21,7 +21,7 @@ banner-button-title: View GSA open source code
           <i class="icon flag fa-users"></i>
           <h3>M-16-21</h3>
           <p>The White House policy telling federal agencies to account for code developed by the agency and publish at least 20% to the public.</p>
-          <div class="usa-button-block"><a href="https://sourcecode.cio.gov/" class="usa-button  usa-button-outline">View</a>
+          <div class="usa-button-block"><a href="https://obamawhitehouse.archives.gov/sites/default/files/omb/memoranda/2016/m_16_21.pdf" class="usa-button  usa-button-outline">View</a>
           </div>
       </div>
 


### PR DESCRIPTION
As we determine how to move forward with open.gsa.gov, there are some issues with broken links and tech stack references. There is an argument that we should remove entirely the section on `code` that refers to `M-16-21`, OSS Policy, and Implementation, given that the first link is broken and the latter two pages are woefully out of date.

That said, this pull request leaves them for now, fixing the link to the memo and updates the tech stack references on the page. Correcting those references is especially important; we should accurately describe the open-source stacks on our open source website!