### PR TITLE
Removes deprecated apis

### DIFF
--- a/_data/api-list.yml
+++ b/_data/api-list.yml
@@ -22,18 +22,12 @@
 - title: Digital.gov API
   description: Content API for the Digital.gov website.
   url: https://open.gsa.gov/api/digitalgov/
-- title: eMuseum API
-  description: This API delivers search information and images from The Museum System (TMS) & eMuseum to GSA.gov.
-  url: https://gsa.github.io/eMuseum-API/
 - title: Federal Procurement Data System - FPDS API
   description: SOAP and XML web services are used in FPDS-NG to provide interoperability with various federal procurement systems.
   url: https://www.fpds.gov/fpdsng_cms/index.php/en/worksite.html
 - title: Fleet Vehicles API
   description: GSA Fleet Drive-thru offers two reports through an API for GSA Fleet Leasing customers.
   url: https://www.gsa.gov/buying-selling/products-services/transportation-logistics-services/vehicle-leasing/gsa-fleet-drivethru
-- title: Go.USA.gov API
-  description: Go.USA.gov is a URL shortener for government employees. The API can shorten, preview, and show clicks on short URLs.
-  url: https://go.usa.gov/api
 - title: GSA IT Collect Public API
   description: The IT Collect API provides a way for the general public to access government-wide IT Portfolio Management and other related IT data sources. 
   url: https://open.gsa.gov/api/itcollect/

--- a/_data/search.yml
+++ b/_data/search.yml
@@ -11590,16 +11590,6 @@
   contact:
     email: github-admins@gsa.gov
   url: https://github.com/GSA/data-json
-- title: eMuseum-API
-  body: API documentation for the eMuseum API
-  license: https://github.com/GSA/eMuseum-API/blob/gh-pages/LICENSE
-  openSourceProject: 1
-  governmentWideReuseProject: 1
-  tags:
-  - GSA
-  contact:
-    email: github-admins@gsa.gov
-  url: https://github.com/GSA/eMuseum-API
 - title: seo
   body: Resources and Materials for Search Engine Optimization for .Gov Websites
   license: https://github.com/GSA/seo/blob/master/LICENSE
@@ -13059,26 +13049,10 @@
   body: The Discovery API drives the Discovery Market Research Tool. It contains information on various GSA services contracts and the awarded vendors, such as their contracting history, their eligibility for contract awards, and their small business designations.
   url: https://discovery.gsa.gov/api/
   category: APIs
-- title: eMuseum API
-  body: This API delivers search information and images from The Museum System (TMS) & eMuseum to GSA.gov.
-  url: https://gsa.github.io/eMuseum-API/
-  category: APIs
-  tags:
-    - API
-    - Fine arts
-    - TMS
 - title: Federal Procurement Data System - FPDS API
   body: SOAP and XML web services are used in FPDS-NG to provide interoperability with various federal procurement systems.
   url: https://www.fpds.gov/fpdsng_cms/index.php/en/worksite.html
   category: APIs
-- title: Go.USA.gov API
-  body: Go.USA.gov is a URL shortener for government employees. The API can shorten, preview, and show clicks on short URLs.
-  url: https://go.usa.gov/api
-  category: APIs
-  tags:
-    - API
-    - URL shortener
-    - Sharing
 - title: GSA.gov Content API
   body: The GSA.gov content API is an XML feed which supplies the public with a means to extract data out of the GSA.gov website. When the API returns multiple content items, it list them with the newest item(s) first, and oldest last.
   url: https://www.gsa.gov/about-us/gsa-content-api

--- a/code.json
+++ b/code.json
@@ -4202,6 +4202,36 @@
       "organization": "GSA"
     },
     {
+      "name": "eMuseum-API",
+      "description": "API documentation for the eMuseum API",
+      "permissions": {
+        "licenses": [
+          {
+            "URL": "http://choosealicense.com/licenses/other/",
+            "name": "other"
+          }
+        ],
+        "usageType": "openSource"
+      },
+      "tags": [
+        "GSA"
+      ],
+      "repositoryURL": "https://github.com/GSA/eMuseum-API",
+      "homepageURL": "https://gsa.github.io/eMuseum-API",
+      "contact": {
+        "email": "gsa-github.support@gsa.gov"
+      },
+      "languages": [
+        "Ruby",
+        "JavaScript",
+        "CSS",
+        "HTML"
+      ],
+      "laborHours": 0,
+      "vcs": "git",
+      "organization": "GSA"
+    },
+    {
       "name": "seo",
       "description": "Resources and Materials for Search Engine Optimization for .Gov Websites",
       "permissions": {
@@ -12113,6 +12143,35 @@
       "contact": {
         "email": "gsa-github.support@gsa.gov"
       },
+      "laborHours": 0,
+      "vcs": "git",
+      "organization": "GSA"
+    },
+    {
+      "name": "go.usa.gov",
+      "description": "go.usa.gov",
+      "permissions": {
+        "licenses": null,
+        "usageType": "openSource"
+      },
+      "tags": [
+        "GSA"
+      ],
+      "repositoryURL": "https://github.com/GSA/go.usa.gov",
+      "contact": {
+        "email": "gsa-github.support@gsa.gov"
+      },
+      "languages": [
+        "PHP",
+        "CSS",
+        "HTML",
+        "JavaScript",
+        "Shell",
+        "ActionScript",
+        "AngelScript",
+        "Dockerfile",
+        "Hack"
+      ],
       "laborHours": 0,
       "vcs": "git",
       "organization": "GSA"

--- a/code.json
+++ b/code.json
@@ -4202,36 +4202,6 @@
       "organization": "GSA"
     },
     {
-      "name": "eMuseum-API",
-      "description": "API documentation for the eMuseum API",
-      "permissions": {
-        "licenses": [
-          {
-            "URL": "http://choosealicense.com/licenses/other/",
-            "name": "other"
-          }
-        ],
-        "usageType": "openSource"
-      },
-      "tags": [
-        "GSA"
-      ],
-      "repositoryURL": "https://github.com/GSA/eMuseum-API",
-      "homepageURL": "https://gsa.github.io/eMuseum-API",
-      "contact": {
-        "email": "gsa-github.support@gsa.gov"
-      },
-      "languages": [
-        "Ruby",
-        "JavaScript",
-        "CSS",
-        "HTML"
-      ],
-      "laborHours": 0,
-      "vcs": "git",
-      "organization": "GSA"
-    },
-    {
       "name": "seo",
       "description": "Resources and Materials for Search Engine Optimization for .Gov Websites",
       "permissions": {
@@ -12143,35 +12113,6 @@
       "contact": {
         "email": "gsa-github.support@gsa.gov"
       },
-      "laborHours": 0,
-      "vcs": "git",
-      "organization": "GSA"
-    },
-    {
-      "name": "go.usa.gov",
-      "description": "go.usa.gov",
-      "permissions": {
-        "licenses": null,
-        "usageType": "openSource"
-      },
-      "tags": [
-        "GSA"
-      ],
-      "repositoryURL": "https://github.com/GSA/go.usa.gov",
-      "contact": {
-        "email": "gsa-github.support@gsa.gov"
-      },
-      "languages": [
-        "PHP",
-        "CSS",
-        "HTML",
-        "JavaScript",
-        "Shell",
-        "ActionScript",
-        "AngelScript",
-        "Dockerfile",
-        "Hack"
-      ],
       "laborHours": 0,
       "vcs": "git",
       "organization": "GSA"


### PR DESCRIPTION
- Fixes [#874](https://github.com/GSA/cto-website/issues/874) and [#875](https://github.com/GSA/cto-website/issues/875)
- Removes documentation references for `emuseum` and `go.usa`
