### PR TITLE
Fix API Key retrieval URL in documentation

### DIFF
--- a/_apidocs/contract-awards.md
+++ b/_apidocs/contract-awards.md
@@ -111,7 +111,7 @@ The Contract Awards API can be used to pull the deleted contracts by sending the
 
 #### Individual (Personal) Accounts
 
-* The SAM.gov Federal or non-Federal registered users must obtain the API Key from the https://sam.gov/profile/details page using the field, “Public API Key”.<br>
+* The SAM.gov Federal or non-Federal registered users must obtain the API Key from the https://sam.gov/profile/details](https://sam.gov/workspace/profile/account-details page using the field, “Public API Key”.<br>
   ![image info](v1/EYE_IMAGE.JPG)  
 * Click on the “Eye” icon, enter the “Enter One-time Password” (this value will be sent to your email address that is associated with your registered account), hit “Submit”, for the API Key value to appear in the box.
 

--- a/_apidocs/contract-awards.md
+++ b/_apidocs/contract-awards.md
@@ -111,7 +111,7 @@ The Contract Awards API can be used to pull the deleted contracts by sending the
 
 #### Individual (Personal) Accounts
 
-* The SAM.gov Federal or non-Federal registered users must obtain the API Key from the https://sam.gov/profile/details](https://sam.gov/workspace/profile/account-details page using the field, “Public API Key”.<br>
+* The SAM.gov Federal or non-Federal registered users must obtain the API Key from the https://sam.gov/workspace/profile/account-details page using the field, “Public API Key”.<br>
   ![image info](v1/EYE_IMAGE.JPG)  
 * Click on the “Eye” icon, enter the “Enter One-time Password” (this value will be sent to your email address that is associated with your registered account), hit “Submit”, for the API Key value to appear in the box.
 

--- a/_apidocs/entity-api.md
+++ b/_apidocs/entity-api.md
@@ -77,7 +77,7 @@ Following are the key features of the Entity Management Extract API:
 
 ### Individual (Personal) Accounts
 
-* The SAM.gov Federal or non-Federal registered users must obtain the API Key from the https://sam.gov/profile/details page using the field, “Public API Key”.<br>
+* The SAM.gov Federal or non-Federal registered users must obtain the API Key from the https://sam.gov/workspace/profile/account-details page using the field, “Public API Key”.<br>
   ![image info](v1/EYE_IMAGE.JPG)
 * Click on the “Eye” icon, enter the “Enter One-time Password” (this value will be sent to your email address that is associated with your registered account), hit “Submit”, for the API Key value to appear in the box.
 

--- a/_apidocs/exclusions-api.md
+++ b/_apidocs/exclusions-api.md
@@ -30,7 +30,7 @@ Exclusions API can be accessed from Production or Alpha with the following versi
 * Alpha Version 4: https://api-alpha.sam.gov/entity-information/v4/exclusions?api_key=< value ><br><br>
 
 Generating a personal API Key:
-* Registered users can request for a public API on 'Account Details' page. This page can be accessed here: <a href="https://sam.gov/profile/details" target="_blank">Account Details page on sam.gov</a>
+* Registered users can request for a public API on 'Account Details' page. This page can be accessed here: <a href="https://sam.gov/workspace/profile/account-details" target="_blank">Account Details page on sam.gov</a>
 * Users must enter their password on ‘Account Details’ page to view the API Key information. If an incorrect password is entered, an error will be returned.
 * After the API Key is generated on ‘Account Details’ page, the API Key can be viewed on the Account Details page immediately. The API Key is visible until users navigate to a different page.
 * If an error is encountered during the API Key generation/retrieval, then users will receive an error message and they can try again.

--- a/_apidocs/sam-entity-extracts-api.md
+++ b/_apidocs/sam-entity-extracts-api.md
@@ -146,7 +146,7 @@ E.g.: The file generated on 04/05/2022 will show 2022095.</li>
 
 ### Individual (Personal) Accounts
 
-* The SAM.gov Federal or non-Federal registered users must obtain the API Key from the https://sam.gov/profile/details page using the field, “Public API Key”.<br>
+* The SAM.gov Federal or non-Federal registered users must obtain the API Key from the https://sam.gov/workspace/profile/account-details page using the field, “Public API Key”.<br>
   ![image info](v1/EYE_IMAGE.JPG)
 * Click on the “Eye” icon, enter the “Enter One-time Password” (this value will be sent to your email address that is associated with your registered account), hit “Submit”, for the API Key value to appear in the box.
 


### PR DESCRIPTION
Updated the URL for obtaining the API Key for SAM.gov users.