### PR TITLE
Apidocs regulationsgov 20260522 signed

### DIFF
--- a/_apidocs/regulationsgov.md
+++ b/_apidocs/regulationsgov.md
@@ -119,7 +119,7 @@ By registering for, receiving and using a key to the Comment API, the key holder
 
 ## API Description
 
-Regulations.gov offers a GET API for documents, comments, and dockets and a POST API for comments. These endpoints can be used for searching documents, comments and dockets, and posting a comment.
+Regulations.gov offers a GET API for documents, comments, dockets, and a POST API for comments. These endpoints can be used for searching documents, comments, dockets, and posting a comment.
 
 #### Searching for documents
 

--- a/_apidocs/regulationsgov.md
+++ b/_apidocs/regulationsgov.md
@@ -89,7 +89,7 @@ If you want to use commenting API, you MUST use the form below to register for a
 <noscript>Please enable JavaScript to signup for an <a href="http://api.data.gov/">api.data.gov</a> API key.</noscript>
 {% endraw %}  
 
-Comment posting capability of API key is available to authorized federal government entities only.
+In order to enable commenting, please contact the [Regulations.gov Help desk](https://www.regulations.gov/support) and provide the first 5 digits of your API key, organization name, organization full address, organization phone number, tax ID and the email address used to sign up for the key. You will be notified when your API key is ready for posting comments. In order to activate your API key, these data elements are required to run an entity validation search.
 
 After registration, you will need to provide this API key in the `X-Api-Key` HTTP header with every API request.
 

--- a/_apidocs/regulationsgov.md
+++ b/_apidocs/regulationsgov.md
@@ -119,7 +119,7 @@ By registering for, receiving and using a key to the Comment API, the key holder
 
 ## API Description
 
-Regulations.gov offers a GET API for documents, comments, and dockets and a POST API for comments. These endpoints can be used for searching document, comments and dockets, and posting a comment.
+Regulations.gov offers a GET API for documents, comments, and dockets and a POST API for comments. These endpoints can be used for searching documents, comments and dockets, and posting a comment.
 
 #### Searching for documents
 

--- a/_apidocs/regulationsgov.md
+++ b/_apidocs/regulationsgov.md
@@ -89,6 +89,8 @@ If you want to use commenting API, you MUST use the form below to register for a
 <noscript>Please enable JavaScript to signup for an <a href="http://api.data.gov/">api.data.gov</a> API key.</noscript>
 {% endraw %}  
 
+Comment posting capability of API key is available to authorized federal government entities only.
+
 After registration, you will need to provide this API key in the `X-Api-Key` HTTP header with every API request.
 
 | HTTP Header Name | Description |
@@ -97,9 +99,27 @@ After registration, you will need to provide this API key in the `X-Api-Key` HTT
 
 <p><small><a href="#">Back to top</a></small></p>
 
+## Terms of Participation
+
+The eRulemaking post Application Programming Interface (API), informally referred to as the Comment API, is provided as a convenience to facilitate the bulk upload of comments from a number of different commenters. The use of the Comment API requires a key, which may be obtained through the [open GSA](https://open.gsa.gov/api/regulationsgov/#getting-started) website. 
+
+By registering for, receiving and using a key to the Comment API, the key holder agrees to the following terms and conditions:
+
+1. When developing interfaces for commenters who will submit comment language and/or attachments through the Comment API, the key holder will include in the interface:
+      1. A link to the same [terms of participation](https://www.regulations.gov/user-notice) and [privacy notice](https://www.regulations.gov/privacy-notice) that users encounter on the comment form for Regulations.gov, and
+      2. A link to the Federal Register notice or other specific document in Regulations.gov for which the key holder is collecting or facilitating comments to be delivered through the Comment API.
+
+2. The key holder certifies that:
+      1. I will only submit comments through the Comment API that it has gathered through lawful means and that, to the best of the key holder’s knowledge, represent comments from real persons, and 
+      2. It has not and will not submit comments of its own creation under fictitious or misappropriated identities or otherwise in violation of federal law.
+
+3. The API key may be disabled if an API key holder is determined to have violated these Terms of Participation. 
+
+<p><small><a href="#">Back to top</a></small></p>
+
 ## API Description
 
-Regulations.gov offers a GET API for documents, comments, and dockets. These endpoints can be used for searching documents, comments, and dockets.
+Regulations.gov offers a GET API for documents, comments, and dockets and a POST API for comments. These endpoints can be used for searching document, comments and dockets, and posting a comment.
 
 #### Searching for documents
 
@@ -128,6 +148,20 @@ A docket is an organizational folder containing multiple documents. Dockets can 
 #### Detailed information for a single docket
 
 In order to obtain more details about a single docket, you can use the endpoint `/v4/dockets/{docketId}`. Each docket has its own set of attributes, which vary based on the Agency posting the docket. Another defining characteristic is if the docket is a Rulemaking or a Nonrulemaking Docket
+
+#### Posting a comment
+
+User can post a comment using the endpoint `/v4/comments`. User can post the comment using one of the following submitter types:
+
+* Individual
+* Organization
+* Anonymous
+
+If user would like to attach files with their submission, user can get a presigned url for the amazon s3 bucket using the endpoint `/v4/file-upload-urls`
+
+A submissionKey can be retrieved using `/v4/submission-keys` endpoint.
+
+submissionType should be set to API.
 
 <p><small><a href="#">Back to top</a></small></p>
   
@@ -181,6 +215,31 @@ Agency configured fields can be updated by an agency at any point in time and ma
 * email
 * phone
 * fax
+  
+## Post Comment API Validation
+  
+#### Common Validations for all comments
+  
+* `commentOnDocumentId`, `comment` and `submissionType` are required fields.
+* If `sendEmailReceipt` is true, `email` field is required.
+* An emoji is not a valid character.
+* If a field has a maximum length requirement, the requirement is applied to both, the number of characters and the number of bytes. 
+* `submitterType` field must be one of these allowed values: `ANONYMOUS`, `INDIVIDUAL`, `ORGANIZATION`.
+* `submissionType` field must be set to `API`.
+* Field value for `comment` must be less than or equals to 5000 characters/bytes.
+* Field value for `email` must be less than or equals to 100 characters/bytes.
+  
+#### Individual Comment Validations
+
+* `firstName` and `lastName` are required fields.
+* Field value for `firstName` and `lastName` must be less than or equals to 25 characters/bytes.
+* Field value for `city`, `stateProvinceRegion`, `phone` and `country` must be less than or equals to 50 characters/bytes.
+* Field value for `zip` field must have less than or equals to 10 characters/bytes.
+  
+#### Organization Comment Validations
+
+* `organization` and `organizationType` are required fields.
+* Field value for `organization` field must have less than or equals to 120 characters/bytes.
 
 ## Examples
 
@@ -370,6 +429,146 @@ To retrieve detailed information on a docket, the following query can be used:
 https://api.regulations.gov/v4/dockets/EPA-HQ-OAR-2003-0129?api_key=DEMO_KEY
 ```
 
+#### Posting a comment
+
+* Posting an anonymous comment without attachment:
+
+  ```json
+  POST https://api.regulations.gov/v4/comments {
+    "data": {
+      "attributes": {
+        "commentOnDocumentId":"FDA-2009-N-0501-0012",
+        "comment":"test comment",
+        "submissionType":"API",
+        "submitterType":"ANONYMOUS"
+      },
+      "type":"comments"
+    }
+  }
+  ```
+
+  Note: No submission key is needed for comments with no attached files.
+
+* Posting a comment with attachment:
+
+  * Step 1: Get a submission key: 
+  
+    ```json
+    POST https://api.regulations.gov/v4/submission-keys {
+      "data": {
+        "type":"submission-keys"
+      }
+    }
+    ```
+
+  * Step 2: Get presigned url for each attachment:
+  
+    ```json
+    POST https://api.regulations.gov/v4/file-upload-urls {
+      "data": {
+        "type":"file-upload-urls",
+        "attributes": {
+          "fileName":"test.jpg",
+          "submissionKey":"kex-d31z-fe04",
+          "contentType":"image/jpeg"
+        }
+      }
+    }
+    ```
+
+  * Step 3: Upload binaries to presigned url
+
+  * Step 4: Submit your comment
+  
+    ```json
+    POST https://api.regulations.gov/v4/comments {
+      "data": {
+        "attributes": {
+          "commentOnDocumentId":"FDA-2009-N-0501-0012",
+          "comment":"test comment",
+          "submissionType":"API",
+          "submissionKey":"kex-d31z-fe04",
+          "submitterType":"ANONYMOUS",
+          "files":[ "test.jpg" ]
+        },
+        "type":"comments"
+      }
+    }
+    ```
+
+* Posting a comment with agency category:
+
+  * Step 1: Get agency categories for agency: 
+  
+    ```
+    https://api.regulations.gov/v4/agency-categories?filter[acronym]=FDA&api_key=DEMO_KEY
+    ```
+
+  * Step 2: Submit your comment with category:
+  
+    ```json
+    POST https://api.regulations.gov/v4/comments {
+      "data": {
+        "attributes": {
+          "commentOnDocumentId":"FDA-2009-N-0501-0012",
+          "comment":"test comment",
+          "submissionType":"API",
+          "submitterType":"ANONYMOUS",
+          "category":"Academia - E0007"
+        },
+        "type":"comments"
+      }
+    }
+    ```
+* Posting multiple submissions in a single comment:
+
+  To post a comment with attachment that carries 5 submissions, user should follow the following steps:
+
+  * Step 1: Get a submission key: 
+  
+    ```json
+    POST https://api.regulations.gov/v4/submission-keys {
+      "data": {
+        "type":"submission-keys"
+      }
+    }
+    ```
+
+  * Step 2: Get presigned url for the attachment with multiple submissions:
+  
+    ```json
+    POST https://api.regulations.gov/v4/file-upload-urls {
+      "data": {
+        "type":"file-upload-urls",
+        "attributes": {
+          "fileName":"multipleSubmissions.pdf",
+          "submissionKey":"kex-d31z-fe04",
+          "contentType":"image/jpeg"
+        }
+      }
+    }
+    ```
+
+  * Step 3: Upload binaries to presigned url
+
+  * Step 4: Submit your comment with 
+  
+    ```json
+    POST https://api.regulations.gov/v4/comments {
+      "data": {
+        "attributes": {
+          "commentOnDocumentId":"FDA-2009-N-0501-0012",
+          "comment":"test comment",
+          "submissionType":"API",
+          "submissionKey":"kex-d31z-fe04",
+          "submitterType":"ANONYMOUS",
+          "files":[ "multipleSubmissions.pdf" ],
+          "numItemsReceived": 5
+        },
+        "type":"comments"
+      }
+    }
+    ```
 <p><small><a href="#">Back to top</a></small></p>
 
 ## OpenAPI Specification File
@@ -401,6 +600,14 @@ We have added an example that shows how to retrieve more than 5000 comments on a
 
 Please note the new parameter `lastModifiedDate` is in beta and may be removed when we have a permanent bulk download solution available.
 
+#### I submitted a comment, but I am unable to find it on regs. What happened to my comment?
+
+Comments created via API are not made available in Regulations.gov right away. Agencies need to approve before the newly created comment can be posted out to Regulations.gov.
+
+#### I am seeing 400 errors from commenting API. What am I doing wrong?
+
+Please make sure you are setting Content-Type to application/vnd.api+json in request header.
+
 #### What is DEMO_KEY api key?
 
 As indicated by name, DEMO_KEY should only be used for demonstration purposes. We have added this api_key to our examples to make it easier for users to copy/paste the urls. It should not be used for anything more than exploring our APIs. 
@@ -415,7 +622,7 @@ Please review https://api.data.gov/docs/rate-limits/ for information on rate lim
   
 #### Can I request rate limit increases for my keys? 
 
-GSA may grant a rate limit increase on the GET keys for an indefinite period. Such requests must establish the need to justify the rate limit increases. Each submission will be reviewed and considered on a case-by-case basis.
+GSA may grant a rate limit increase on the GET keys for an indefinite period. Such requests must establish the need to justify the rate limit increases. Each submission will be reviewed and considered on a case-by-case basis. GSA is unable to increase the rate limits for POST API keys upon requests at this time. However, the current POST API key holders can request one additional key without going through the validation process again.
   
 <p><small><a href="#">Back to top</a></small></p>
 

--- a/_apidocs/regulationsgov/v4/openapi.yaml
+++ b/_apidocs/regulationsgov/v4/openapi.yaml
@@ -265,6 +265,42 @@ paths:
             application/vnd.api+json:
               schema:
                 $ref: '#/components/schemas/JSONError'
+    post:
+      summary: Creates a new comment.
+      tags:
+        - comments
+      requestBody:
+        description: A JSON object containing comment information
+        required: true
+        content:
+          application/vnd.api+json:
+            schema:
+                $ref: '#/components/schemas/JSONResourcePostRequestObject'
+      responses:
+        '201':
+          description: Created
+          content:
+            application/vnd.api+json:
+              schema:
+                $ref: '#/components/schemas/JSONResourcePostResponseObject'
+        '400':
+          description: Validation error
+          content:
+            application/vnd.api+json:
+              schema:
+                $ref: '#/components/schemas/JSONError'
+        '403':
+           description: API key is missing or invalid
+           content:
+            application/vnd.api+json:
+              schema:
+                $ref: '#/components/schemas/JSONError'
+        '404':
+          description: Document not found
+          content:
+            application/vnd.api+json:
+              schema:
+                $ref: '#/components/schemas/JSONError'
   /comments/{commentId}:
     get:
       summary: Get detailed information for specified commentId
@@ -459,6 +495,122 @@ paths:
                         categories:
                           type: string
                           description: The name of the category
+        '400':
+          description: Validation error
+          content:
+            application/vnd.api+json:
+              schema:
+                $ref: '#/components/schemas/JSONError'
+        '403':
+           description: API key is missing or invalid
+           content:
+            application/vnd.api+json:
+              schema:
+                $ref: '#/components/schemas/JSONError'
+  /submission-keys:
+    post:
+      summary: Creates the unique submission key
+      operationId: GetSubmitterKey
+      tags:
+        - comment submission utilities
+      requestBody:
+        content: 
+          application/vnd.api+json:
+            schema:
+              type: object
+              properties:
+                data:
+                  type: object
+                  properties:
+                    type:
+                      type: string
+                      example: 'submissionKeys'
+      responses:
+        '201':
+          description: Created
+          content:
+            application/vnd.api+json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: object
+                    properties:
+                        id:
+                          type: string
+                          description: the newly created submission key
+                        type:
+                          type: string
+                          example: 'submission-keys'
+                        links:
+                          $ref: '#/components/schemas/SelfLink'
+        '403':
+           description: API key is missing or invalid
+           content:
+            application/vnd.api+json:
+              schema:
+                $ref: '#/components/schemas/JSONError'      
+  /file-upload-urls:
+    post:
+      summary: Creates a presigned url to upload file
+      tags:
+        - comment submission utilities
+      description: 'Returns a pre-signed URL to upload a file to the S3 bucket'
+      requestBody:
+        required: true
+        content: 
+          application/vnd.api+json:
+            schema:
+              type: object
+              properties:
+                data:
+                  type: object
+                  properties:
+                    type:
+                      type: string
+                      example: 'file-upload-urls'
+                    attributes:
+                      type: object
+                      properties: 
+                        submissionKey:
+                          type: string
+                          description: submission key for the submission
+                        fileName:
+                          type: string
+                          description: name of the file to upload
+                        contentType:
+                          type: string
+                          description: content type of the file
+      responses:
+        '201':
+          description: Created
+          content:
+            application/vnd.api+json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                        format: uri
+                        description: The pre-signed url to upload the file
+                      type:
+                        type: string
+                        example: 'file-upload-urls'
+                      attributes:
+                        type: object
+                        properties: 
+                          submissionKey:
+                            type: string
+                            description: submission key for the submission
+                          fileName:
+                            type: string
+                            description: name of the file to upload
+                          contentType:
+                            type: string
+                            description: content type of the file
         '400':
           description: Validation error
           content:

--- a/_data/api-list.yml
+++ b/_data/api-list.yml
@@ -29,7 +29,7 @@
   description: This API contains the allowed reimbursement rates for hotel stays and meals for federal travelers.
   url: https://open.gsa.gov/api/perdiem/
 - title: Regulations.gov API
-  description: Regulations.gov offers a GET API that allows searching for documents, comments, and dockets.
+  description: Regulations.gov offers a GET API that allows searching for documents, comments, and dockets. Additionally,  a POST API is offered that allows users to submit comments.
   url: https://open.gsa.gov/api/regulationsgov/
 - title: SAM.gov Assistance Listings Public API
   description: The Assistance Listings Public API provides Active and Inactive federal assistance listings data, similar to the CFDA catalog.


### PR DESCRIPTION
OIRA instructed we re-enable the ability to POST comments to regulations.gov via the API. When the functionality was disabled, an effort was made to remove the API related reference language from this repo. This PR reverts the two commits that initially removed the language. 

Initial PRs:
https://github.com/GSA/open-gsa-redesign/pull/1500
https://github.com/GSA/open-gsa-redesign/pull/1525