### PR TITLE
Update link to Touchpoints API docs in API directory

### DIFF
--- a/_data/api-list.yml
+++ b/_data/api-list.yml
@@ -88,9 +88,9 @@
 - title: TMSS 2.0 Rate Query API
   description: TMSS 2.0 Rate Query API provides shipment cost for a regular Household Goods (HHG) shipment or for an Extended Storage (EXSTG) shipment.
   url: https://open.gsa.gov/api/ratequeryhhg/
-- title: Touchpoints
-  description: Touchpoints makes customer feedback easier for federal agencies, and Touchpoints API provides an convenient, programmatic way to access the data for your Forms and Responses.
-  url: https://github.com/gsa/touchpoints/wiki/API
+- title: Touchpoints API
+  description: Touchpoints makes customer feedback easier for federal agencies, and the Touchpoints API provides an convenient, programmatic way to access the data for your Forms and Responses.
+  url: https://touchpoints.digital.gov/api-overview/
 #- title: System for Award Management API
 #  description: A RESTful method of retrieving public information about the businesses or individuals within the System for Award Management data set.
 #  url: https://gsa.github.io/sam_api/sam/

--- a/_data/api-list.yml
+++ b/_data/api-list.yml
@@ -89,7 +89,7 @@
   description: TMSS 2.0 Rate Query API provides shipment cost for a regular Household Goods (HHG) shipment or for an Extended Storage (EXSTG) shipment.
   url: https://open.gsa.gov/api/ratequeryhhg/
 - title: Touchpoints API
-  description: Touchpoints makes customer feedback easier for federal agencies, and the Touchpoints API provides an convenient, programmatic way to access the data for your Forms and Responses.
+  description: For Touchpoints customers. The Touchpoints API provides an convenient, programmatic way to access the data for your Forms and Responses.
   url: https://touchpoints.digital.gov/api-overview/
 #- title: System for Award Management API
 #  description: A RESTful method of retrieving public information about the businesses or individuals within the System for Award Management data set.


### PR DESCRIPTION
We recently added API documentation to the Touchpoints [documentation site](https://touchpoints.digital.gov/). This PR updates the Touchpoints link on open.gsa.gov's API directory page to point to the new documentation. Currently, the link points to an out-of-date documentation page on the Touchpoints Github wiki.